### PR TITLE
Added check for empty string for database env variable

### DIFF
--- a/collect_CFME_archive_script.sh
+++ b/collect_CFME_archive_script.sh
@@ -3,8 +3,9 @@
 # save directory from which command is initiated
 collect_logs_directory=$(pwd)
 
-# make the vmdb/log directory the current directory 
-pushd /var/www/miq/vmdb
+# make the vmdb/log directory the current directory
+vmdb_logs_directory="/var/www/miq/vmdb"
+pushd ${vmdb_logs_directory}
 
 # eliminiate any prior collected logs to make sure that only one collection is current
 rm -f log/evm_full_archive_$(uname -n)* log/evm_archived_$(uname -n)*
@@ -12,27 +13,20 @@ rm -f log/evm_full_archive_$(uname -n)* log/evm_archived_$(uname -n)*
 #Source in the file so that we can call postgresql functions
 source /etc/default/evm
 
+tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 
-output_tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
-
-if [ -z "$APPLIANCE_PG_DATA"] && [ -d "$APPLIANCE_PG_DATA" ]; then
-
+if [[ -z "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA" ]]; then
     echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
-
-    XZ_OPT=-9 tar -cJvf ${output_tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
-
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
 else
-
     echo "This CloudForms appliance is not a Database server"
     echo " Log collection starting:"
-
-    XZ_OPT=-9 tar -cJvf log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/* /var/log/* log/apache/*
-
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/* /var/log/* log/apache/*
 fi
-
-echo "Copy ${ouput_tarball} to ${collect_logs_directory}"
-cp ${output_tarball} ${collect_logs_directory}
 
 # and restore previous current directory
 popd
+
+# let the user know where the archive is
+echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"

--- a/collect_CFME_archive_script.sh
+++ b/collect_CFME_archive_script.sh
@@ -1,24 +1,38 @@
 #!/bin/bash
-collect_logs_directory=$(pwd)
+
 # save directory from which command is initiated
-pushd /var/www/miq/vmdb
+collect_logs_directory=$(pwd)
+
 # make the vmdb/log directory the current directory 
-rm -f log/evm_full_archive_$(uname -n)* log/evm_archived_$(uname -n)*
+pushd /var/www/miq/vmdb
+
 # eliminiate any prior collected logs to make sure that only one collection is current
+rm -f log/evm_full_archive_$(uname -n)* log/evm_archived_$(uname -n)*
 
 #Source in the file so that we can call postgresql functions
 source /etc/default/evm
 
-if [ -d "$APPLIANCE_PG_DATA" ]
-then
-echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
-echo " Log collection starting:"
-XZ_OPT=-9 tar -cJvf log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+
+output_tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
+
+if [ -z "$APPLIANCE_PG_DATA"] && [ -d "$APPLIANCE_PG_DATA" ]; then
+
+    echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
+    echo " Log collection starting:"
+
+    XZ_OPT=-9 tar -cJvf ${output_tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
 
 else
-echo "This CloudForms appliance is not a Database server"
-echo " Log collection starting:"
-XZ_OPT=-9 tar -cJvf log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/* /var/log/* log/apache/*
+
+    echo "This CloudForms appliance is not a Database server"
+    echo " Log collection starting:"
+
+    XZ_OPT=-9 tar -cJvf log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/* /var/log/* log/apache/*
+
 fi
+
+echo "Copy ${ouput_tarball} to ${collect_logs_directory}"
+cp ${output_tarball} ${collect_logs_directory}
+
 # and restore previous current directory
 popd

--- a/collect_CFME_current_script.sh
+++ b/collect_CFME_current_script.sh
@@ -4,7 +4,8 @@
 collect_logs_directory=$(pwd)
 
 # make the vmdb/log directory the current directory 
-pushd /var/www/miq/vmdb
+vmdb_logs_directory="/var/www/miq/vmdb"
+pushd ${vmdb_logs_directory}
 
 # eliminiate any prior collected logs to make sure that only one collection is current
 rm -f log/evm_full_archive_$(uname -n)* log/evm_current_$(uname -n)*
@@ -12,27 +13,21 @@ rm -f log/evm_full_archive_$(uname -n)* log/evm_current_$(uname -n)*
 #Source in the file so that we can call postgresql functions
 source /etc/default/evm
 
-output_tarball="log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
+tarball="log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 
-if [ -z "$APPLIANCE_PG_DATA"] && [ -d "$APPLIANCE_PG_DATA" ]; then
-
+if [[ -z "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA" ]]; then
     echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
-
-    XZ_OPT=-9 tar -cJvf ${output_tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
 $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
-
 else
-
     echo "This CloudForms appliance is not a Database server"
     echo " Log collection starting:"
-
-    XZ_OPT=-9 tar -cJvf ${output_tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
-
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
 fi
-
-echo "Copy ${output_tarball} to ${collect_logs_directory}"
-cp ${output_tarball} ${collect_logs_directory}
 
 # and restore previous current directory
 popd
+
+# let the user know where the archive is
+echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"

--- a/collect_CFME_current_script.sh
+++ b/collect_CFME_current_script.sh
@@ -1,27 +1,38 @@
 #!/bin/bash
-collect_logs_directory=$(pwd)
+
 # save directory from which command is initiated
-pushd /var/www/miq/vmdb
+collect_logs_directory=$(pwd)
+
 # make the vmdb/log directory the current directory 
-rm -f log/evm_full_archive_$(uname -n)* log/evm_current_$(uname -n)*
+pushd /var/www/miq/vmdb
+
 # eliminiate any prior collected logs to make sure that only one collection is current
+rm -f log/evm_full_archive_$(uname -n)* log/evm_current_$(uname -n)*
 
 #Source in the file so that we can call postgresql functions
 source /etc/default/evm
 
-if [ -d "$APPLIANCE_PG_DATA" ]
-then
+output_tarball="log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 
-echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
-echo " Log collection starting:"
-XZ_OPT=-9 tar -cJvf log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
+if [ -z "$APPLIANCE_PG_DATA"] && [ -d "$APPLIANCE_PG_DATA" ]; then
+
+    echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
+    echo " Log collection starting:"
+
+    XZ_OPT=-9 tar -cJvf ${output_tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
 $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
 
 else
-echo "This CloudForms appliance is not a Database server"
-echo " Log collection starting:"
-XZ_OPT=-9 tar -cJvf log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
+
+    echo "This CloudForms appliance is not a Database server"
+    echo " Log collection starting:"
+
+    XZ_OPT=-9 tar -cJvf ${output_tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
 
 fi
+
+echo "Copy ${output_tarball} to ${collect_logs_directory}"
+cp ${output_tarball} ${collect_logs_directory}
+
 # and restore previous current directory
 popd


### PR DESCRIPTION
Hello, I was having trouble getting this script to work on my CFME node. I have a CF cluster and the node doesn't have a database. If "$APPLIANCE_PG_DATA" doesn't exist testing with -d will be true you need to also check -z for a null string because the APPLIANCE_PG_DATA might not be defined. 

I also copy the generated archive to the collection directory so you don't have to go looking for it. 

What do you think?