### PR TITLE
Fix check for if this is database server or not.

### DIFF
--- a/collect_CFME_archive_script.sh
+++ b/collect_CFME_archive_script.sh
@@ -15,7 +15,7 @@ source /etc/default/evm
 
 tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 
-if [[ -z "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA" ]]; then
+if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
     echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
     XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf

--- a/collect_CFME_current_script.sh
+++ b/collect_CFME_current_script.sh
@@ -15,7 +15,7 @@ source /etc/default/evm
 
 tarball="log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
 
-if [[ -z "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA" ]]; then
+if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
     echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
     echo " Log collection starting:"
     XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*


### PR DESCRIPTION
I believe that PR #10 is based upon a false assumption, at least for 4.5 appliances.  $APPLIANCE_PG_DATA is defined on all 4.5 CF appliances, and the directory also exists.  Also, I tested the merged #10 and it finds that all CFME servers are non-database even when they are.  This is due to checking if if $APPLIANCE_PG_DATA is zero instead of non-zero.

This PR addresses both of those concerns.