### PR TITLE
Clean/DRY up of log collection scripts

### DIFF
--- a/collect_CFME_archive_script.sh
+++ b/collect_CFME_archive_script.sh
@@ -8,7 +8,10 @@ vmdb_logs_directory="/var/www/miq/vmdb"
 pushd ${vmdb_logs_directory}
 
 # eliminiate any prior collected logs to make sure that only one collection is current
-rm -f log/evm_full_archive_$(uname -n)* log/evm_archived_$(uname -n)*
+rm -f log/evm_full_archive_$(uname -n)* \
+      log/evm_archived_$(uname -n)*     \
+      log/evm_archive_$(uname -n)*      \
+      log/evm_current_$(uname -n)*
 
 #Source in the file so that we can call postgresql functions
 source /etc/default/evm

--- a/collect_CFME_archive_script.sh
+++ b/collect_CFME_archive_script.sh
@@ -1,35 +1,14 @@
 #!/bin/bash
 
-# save directory from which command is initiated
-collect_logs_directory=$(pwd)
+collection_type="archive"
+vmdb_logs_files="log/*"
 
-# make the vmdb/log directory the current directory
-vmdb_logs_directory="/var/www/miq/vmdb"
-pushd ${vmdb_logs_directory}
-
-# eliminiate any prior collected logs to make sure that only one collection is current
-rm -f log/evm_full_archive_$(uname -n)* \
-      log/evm_archived_$(uname -n)*     \
-      log/evm_archive_$(uname -n)*      \
-      log/evm_current_$(uname -n)*
-
-#Source in the file so that we can call postgresql functions
-source /etc/default/evm
-
-tarball="log/evm_archive_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
-
-if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
-    echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
-    echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+if [[ -e ${BASH_SOURCE%/*} ]]; then
+  starting_dir=$(pwd)
+  cd ${BASH_SOURCE%/*}
+  source ./collect_CFME_logs.sh
+  cd $starting_dir
 else
-    echo "This CloudForms appliance is not a Database server"
-    echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION log/* config/* /var/log/* log/apache/*
+  echo "ERROR:  Unable to find collect log script!"
+  exit 1
 fi
-
-# and restore previous current directory
-popd
-
-# let the user know where the archive is
-echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"

--- a/collect_CFME_archive_script.sh
+++ b/collect_CFME_archive_script.sh
@@ -3,12 +3,4 @@
 collection_type="archive"
 vmdb_logs_files="log/*"
 
-if [[ -e ${BASH_SOURCE%/*} ]]; then
-  starting_dir=$(pwd)
-  cd ${BASH_SOURCE%/*}
-  source ./collect_CFME_logs.sh
-  cd $starting_dir
-else
-  echo "ERROR:  Unable to find collect log script!"
-  exit 1
-fi
+source ${BASH_SOURCE%/*}/collect_CFME_logs.sh

--- a/collect_CFME_current_script.sh
+++ b/collect_CFME_current_script.sh
@@ -1,35 +1,14 @@
 #!/bin/bash
 
-# save directory from which command is initiated
-collect_logs_directory=$(pwd)
+collection_type="current"
+vmdb_logs_files="log/*.log log/*.txt"
 
-# make the vmdb/log directory the current directory 
-vmdb_logs_directory="/var/www/miq/vmdb"
-pushd ${vmdb_logs_directory}
-
-# eliminiate any prior collected logs to make sure that only one collection is current
-rm -f log/evm_full_archive_$(uname -n)* \
-      log/evm_archived_$(uname -n)*     \
-      log/evm_archive_$(uname -n)*      \
-      log/evm_current_$(uname -n)*
-
-#Source in the file so that we can call postgresql functions
-source /etc/default/evm
-
-tarball="log/evm_current_$(uname -n)_$(date +%Y%m%d_%H%M%S).tar.xz"
-
-if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
-    echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
-    echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+if [[ -e ${BASH_SOURCE%/*} ]]; then
+  starting_dir=$(pwd)
+  cd ${BASH_SOURCE%/*}
+  source ./collect_CFME_logs.sh
+  cd $starting_dir
 else
-    echo "This CloudForms appliance is not a Database server"
-    echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files   BUILD GUID VERSION REGION log/*.log log/*.txt config/* /var/log/* log/apache/*
+  echo "ERROR:  Unable to find collect log script!"
+  exit 1
 fi
-
-# and restore previous current directory
-popd
-
-# let the user know where the archive is
-echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"

--- a/collect_CFME_current_script.sh
+++ b/collect_CFME_current_script.sh
@@ -8,7 +8,10 @@ vmdb_logs_directory="/var/www/miq/vmdb"
 pushd ${vmdb_logs_directory}
 
 # eliminiate any prior collected logs to make sure that only one collection is current
-rm -f log/evm_full_archive_$(uname -n)* log/evm_current_$(uname -n)*
+rm -f log/evm_full_archive_$(uname -n)* \
+      log/evm_archived_$(uname -n)*     \
+      log/evm_archive_$(uname -n)*      \
+      log/evm_current_$(uname -n)*
 
 #Source in the file so that we can call postgresql functions
 source /etc/default/evm

--- a/collect_CFME_current_script.sh
+++ b/collect_CFME_current_script.sh
@@ -3,12 +3,4 @@
 collection_type="current"
 vmdb_logs_files="log/*.log log/*.txt"
 
-if [[ -e ${BASH_SOURCE%/*} ]]; then
-  starting_dir=$(pwd)
-  cd ${BASH_SOURCE%/*}
-  source ./collect_CFME_logs.sh
-  cd $starting_dir
-else
-  echo "ERROR:  Unable to find collect log script!"
-  exit 1
-fi
+source ${BASH_SOURCE%/*}/collect_CFME_logs.sh

--- a/collect_CFME_logs.sh
+++ b/collect_CFME_logs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # save directory from which command is initiated
-collect_logs_directory=$(pwd)
+collect_logs_directory=${BASH_SOURCE%/*}
 
 # used in filenames and globs
 vmdb_hostname=$(uname -n)

--- a/collect_CFME_logs.sh
+++ b/collect_CFME_logs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# save directory from which command is initiated
+collect_logs_directory=$(pwd)
+
+# used in filenames and globs
+vmdb_hostname=$(uname -n)
+
+# base name for tar
+tar_base_name="log/evm_full_${collection_type}_${vmdb_hostname}"
+
+# make the vmdb/log directory the current directory
+vmdb_logs_directory="/var/www/miq/vmdb"
+pushd ${vmdb_logs_directory}
+
+# eliminiate any prior collected logs to make sure that only one collection is current
+rm -f log/evm_full_archive_$vmdb_hostname* \
+      log/evm_archived_$vmdb_hostname*     \
+      log/evm_archive_$vmdb_hostname*      \
+      log/evm_current_$vmdb_hostname*
+
+# Source in the file so that we can call postgresql functions
+source /etc/default/evm
+
+tarball="${tar_base_name}_$(date +%Y%m%d_%H%M%S).tar.xz"
+
+if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
+    echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
+    echo " Log collection starting:"
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION $vmd_log_files config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+else
+    echo "This CloudForms appliance is not a Database server"
+    echo " Log collection starting:"
+    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION $vmd_log_files config/* /var/log/* log/apache/*
+fi
+
+# and restore previous current directory
+popd
+
+# let the user know where the archive is
+echo "Archive Written To: ${vmdb_logs_directory}/${tarball}"

--- a/collect_CFME_logs.sh
+++ b/collect_CFME_logs.sh
@@ -24,15 +24,24 @@ source /etc/default/evm
 
 tarball="${tar_base_name}_$(date +%Y%m%d_%H%M%S).tar.xz"
 
+include_files="BUILD GUID VERSION REGION"                              # CFME version/identifiers
+include_files="$include_files $vmd_log_files"                          # CFME log files to include
+include_files="$include_files /var/log/* var/apache/*"                 # System/apache log files
+
 if [[ -n "$APPLIANCE_PG_DATA" && -d "$APPLIANCE_PG_DATA/pg_log" ]]; then
     echo "This CloudForms appliance has a Database server and is running version: $(psql --version)"
-    echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION $vmd_log_files config/*  /var/log/* log/apache/* $APPLIANCE_PG_DATA/pg_log/* $APPLIANCE_PG_DATA/postgresql.conf
+
+    include_files="$include_files $APPLIANCE_PG_DATA/pg_log/*"         # PG log files
+    include_files="$include_files $APPLIANCE_PG_DATA/postgresql.conf"  # PG config files
 else
     echo "This CloudForms appliance is not a Database server"
-    echo " Log collection starting:"
-    XZ_OPT=-9 tar -cJvf ${tarball} --sparse -X $collect_logs_directory/exclude_files BUILD GUID VERSION REGION $vmd_log_files config/* /var/log/* log/apache/*
 fi
+
+
+echo " Log collection starting:"
+XZ_OPT=-9 tar -cJvf ${tarball} --sparse                \
+              -X $collect_logs_directory/exclude_files \
+              $include_files
 
 # and restore previous current directory
 popd


### PR DESCRIPTION
This PR makes a number of changes to the scripts in this repo:

- Addresses `rm -rf` inconsistencies
- Consolidates them into a single main script, and uses vars to pass in the differences
- Allows the scripts to not require being called from the source directory
- Miscellaneous cleanup/refactoring (see individual commits)

These are some suggested changes that go along with a PR to import this script set into MIQ proper:

https://github.com/ManageIQ/manageiq/pull/18156

With some suggested ideas to make it more user friendly that match the review I am giving on it.